### PR TITLE
Removed Moscow campusID from the database.

### DIFF
--- a/env/campusIDs.json
+++ b/env/campusIDs.json
@@ -6,7 +6,6 @@
 	"Brussels": 12,
 	"Helsinki": 13,
 	"Khouribga": 16,
-	"Moscow": 17,
 	"São-Paulo": 20,
 	"Benguerir": 21,
 	"Madrid": 22,


### PR DESCRIPTION
/env/campusIDs.json
> Removed

"Moscow": 17

from the json database.
It was causing a JSON.parse error, which has now been fixed.